### PR TITLE
Fixed up license messages in source files

### DIFF
--- a/OPFService/NetworkService.cs
+++ b/OPFService/NetworkService.cs
@@ -5,13 +5,13 @@
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
 // 
-// Foobar is distributed in the hope that it will be useful,
+// OpenPasswordFilter is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
 // GNU General Public License for more details.
 // 
 // You should have received a copy of the GNU General Public License
-// along with Foobar; if not, write to the Free Software
+// along with OpenPasswordFilter; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 - 1307  USA
 //
 

--- a/OPFService/OPFDictionary.cs
+++ b/OPFService/OPFDictionary.cs
@@ -5,13 +5,13 @@
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
 // 
-// Foobar is distributed in the hope that it will be useful,
+// OpenPasswordFilter is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
 // GNU General Public License for more details.
 // 
 // You should have received a copy of the GNU General Public License
-// along with Foobar; if not, write to the Free Software
+// along with OpenPasswordFilter; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 - 1307  USA
 //
 

--- a/OPFService/Program.cs
+++ b/OPFService/Program.cs
@@ -5,13 +5,13 @@
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
 // 
-// Foobar is distributed in the hope that it will be useful,
+// OpenPasswordFilter is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
 // GNU General Public License for more details.
 // 
 // You should have received a copy of the GNU General Public License
-// along with Foobar; if not, write to the Free Software
+// along with OpenPasswordFilter; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 - 1307  USA
 //
 

--- a/OPFTest/OPFTest.cpp
+++ b/OPFTest/OPFTest.cpp
@@ -5,13 +5,13 @@
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
 // 
-// Foobar is distributed in the hope that it will be useful,
+// OpenPasswordFilter is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
 // GNU General Public License for more details.
 // 
 // You should have received a copy of the GNU General Public License
-// along with Foobar; if not, write to the Free Software
+// along with OpenPasswordFilter; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 - 1307  USA
 //
 // OPFTest.cpp : Defines the entry point for the console application.

--- a/OpenPasswordFilter/dllmain.cpp
+++ b/OpenPasswordFilter/dllmain.cpp
@@ -5,13 +5,13 @@
 // the Free Software Foundation; either version 2 of the License, or
 // (at your option) any later version.
 // 
-// Foobar is distributed in the hope that it will be useful,
+// OpenPasswordFilter is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
 // GNU General Public License for more details.
 // 
 // You should have received a copy of the GNU General Public License
-// along with Foobar; if not, write to the Free Software
+// along with OpenPasswordFilter; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 - 1307  USA
 //
 // --------


### PR DESCRIPTION
I noticed some of the license messages in the source files were not updated to point to the project name. They pointed to Foobar (the example program from the GPL how-to).