### PR TITLE
Fix unquoted service path

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Note, you do not include the `.dll` extension in the registry key -- just `OpenP
 
 Next, you will want to configure the OPF service.  You can do so as follows:
 
-    > sc create OPF binPath= <full path to exe>\opfservice.exe start= boot
+    > sc create OPF binPath= "<full path to exe>\opfservice.exe" start= boot
 
 Finally, create two dictionary files in the same directory where you placed opfservice.exe named `opfmatch.txt` and
 `opfcont.txt`.  These should contain one forbidden password per line, such as:


### PR DESCRIPTION
Service path is vulnerable to path interception if the path has one or more spaces and is not surrounded by quotation marks. See https://attack.mitre.org/wiki/Technique/T1034#Unquoted_Paths