### PR TITLE
OpenPasswordFilter - Multithreading and unicode support

### DIFF
--- a/OPFService/NetworkService.cs
+++ b/OPFService/NetworkService.cs
@@ -56,7 +56,8 @@ namespace OPFService {
                 string command = istream.ReadLine();
                 if (command == "test") {
                     string password = istream.ReadLine();
-                    ostream.WriteLine(dict.contains(password) ? "false" : "true");
+                    bool containsPassword = dict.contains(password);
+                    ostream.WriteLine(containsPassword ? "false" : "true");
                     ostream.Flush();
                 } else {
                     ostream.WriteLine("ERROR");

--- a/OPFService/OPFService.csproj
+++ b/OPFService/OPFService.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
+    <OutputPath>..\x64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -112,6 +112,12 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>powershell.exe -command "stop-service opf -ErrorAction SilentlyContinue"</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>net start opf</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/OpenPasswordFilter/OpenPasswordFilter.vcxproj
+++ b/OpenPasswordFilter/OpenPasswordFilter.vcxproj
@@ -22,6 +22,7 @@
     <ProjectGuid>{C07FD07A-AC42-47B1-8EB7-FF92606245BF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>OpenPasswordFilter</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -49,6 +50,7 @@
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -127,6 +129,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;OPENPASSWORDFILTER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <CompileAsManaged>true</CompileAsManaged>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -164,6 +167,11 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/OpenPasswordFilter/dllmain.cpp
+++ b/OpenPasswordFilter/dllmain.cpp
@@ -39,8 +39,40 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <SubAuth.h>
+#include <process.h>
+#include <codecvt>
 
 #pragma comment(lib, "Ws2_32.lib")
+
+using namespace std;
+
+struct PasswordFilterAccount {
+	PUNICODE_STRING AccountName;
+	PUNICODE_STRING FullName;
+	PUNICODE_STRING Password;
+};
+
+bool bPasswordOk = true;
+
+//
+// make sure all data is sent through the socket
+//
+int sendall(SOCKET s, const char *buf, int *len) {
+	int total = 0;        // how many bytes we've sent
+	int bytesleft = *len; // how many we have left to send
+	int n;
+
+	while (total < *len) {
+		n = send(s, buf + total, bytesleft, 0);
+		if (n == -1) { break; }
+		total += n;
+		bytesleft -= n;
+	}
+
+	*len = total; // return number actually sent here
+
+	return n == -1 ? -1 : 0; // return -1 onm failure, 0 on success
+}
 
 // Regular DLL boilerplate
 
@@ -86,34 +118,45 @@ PasswordChangeNotify(PUNICODE_STRING *UserName,
 //
 //    <connect>
 //    client:   test\n
+//    client:   Username\n
 //    client:   Password1\n
 //    server:   false\n
 //    <disconnect>
 //
-
-BOOLEAN askServer(SOCKET sock, PUNICODE_STRING Password) {
-	char buffer[1024];
-	char *preamble = "test\n";
+void askServer(SOCKET sock, PUNICODE_STRING AccountName, PUNICODE_STRING Password) {
+	using convert_type = std::codecvt_utf8<wchar_t>;
+	std::wstring_convert<convert_type, wchar_t> converter;
+	char rcBuffer[1024];
+	char *preamble = "test\n"; //command that is used to start password testing
 	int i;
+	int len;
 
-	i = send(sock, preamble, (int)strlen(preamble), 0);
+	i = send(sock, preamble, (int)strlen(preamble), 0); //send test command
 	if (i != SOCKET_ERROR) {
-		int length = Password->Length / sizeof(WCHAR);
-		if (length + 2 < sizeof(buffer)) {
-			i = wcstombs(buffer, Password->Buffer, length);
-			buffer[i] = '\n';
-			buffer[i + 1] = '\0';
-			i = send(sock, buffer, (int)strlen(buffer), 0);
-			if (i != SOCKET_ERROR) {
-				i = recv(sock, buffer, sizeof(buffer), 0);
-				if (i > 0 && buffer[0] == 'f') {
-					return FALSE;
-				}
+		std::wstring wPassword(Password->Buffer, Password->Length / sizeof(WCHAR));
+		wPassword.push_back('\n');
+
+		std::string sPassword = converter.to_bytes(wPassword);
+
+		const char * cPassword = sPassword.c_str();
+		len = static_cast<int>(sPassword.size());
+		i = sendall(sock, cPassword, &len);
+
+		//i = send(sock, sPassword.c_str(), sPassword.size(), 0);
+
+		if (i != SOCKET_ERROR) {
+			i = recv(sock, rcBuffer, sizeof(rcBuffer), 0);//read response
+			if (i > 0 && rcBuffer[0] == 'f') {
+				bPasswordOk = FALSE;
 			}
 		}
+		else {
+			//report error
+		}
 	}
-
-	return TRUE;
+	else {
+		//report error
+	}
 }
 
 //
@@ -121,16 +164,15 @@ BOOLEAN askServer(SOCKET sock, PUNICODE_STRING Password) {
 // whether the indicated password is acceptable according to the filter service.
 // The service is a C# program also in this solution, titled "OPFService".
 //
+unsigned int __stdcall CreateSocket(void *v) {
+	//the account object
+	PasswordFilterAccount *pfAccount = static_cast<PasswordFilterAccount*>(v);
 
-extern "C" __declspec(dllexport) BOOLEAN __stdcall PasswordFilter(PUNICODE_STRING AccountName, 
-	                                                              PUNICODE_STRING FullName, 
-																  PUNICODE_STRING Password, 
-																  BOOLEAN SetOperation) {
 	SOCKET sock = INVALID_SOCKET;
 	struct addrinfo *result = NULL;
 	struct addrinfo *ptr = NULL;
 	struct addrinfo hints;
-	BOOLEAN retval = TRUE;
+	bPasswordOk = TRUE; // set fail open
 
 	int i;
 
@@ -142,13 +184,9 @@ extern "C" __declspec(dllexport) BOOLEAN __stdcall PasswordFilter(PUNICODE_STRIN
 	// This butt-ugly loop is straight out of Microsoft's reference example
 	// for a TCP client.  It's not my style, but how can the reference be
 	// wrong? ;-)
-
 	i = getaddrinfo("127.0.0.1", "5999", &hints, &result);
-
 	if (i == 0) {
-
 		for (ptr = result; ptr != NULL; ptr = ptr->ai_next) {
-
 			sock = socket(ptr->ai_family, ptr->ai_socktype, ptr->ai_protocol);
 			if (sock == INVALID_SOCKET) {
 				break;
@@ -163,11 +201,44 @@ extern "C" __declspec(dllexport) BOOLEAN __stdcall PasswordFilter(PUNICODE_STRIN
 		}
 
 		if (sock != INVALID_SOCKET) {
-			retval = askServer(sock, Password);
+			askServer(sock, pfAccount->AccountName, pfAccount->Password);
 			closesocket(sock);
 		}
 	}
-	
-	return retval;
+
+	return bPasswordOk;
 }
 
+extern "C" __declspec(dllexport) BOOLEAN __stdcall PasswordFilter(PUNICODE_STRING AccountName,
+																  PUNICODE_STRING FullName,
+																  PUNICODE_STRING Password,
+																  BOOLEAN SetOperation) {
+
+	//build the account struct
+	PasswordFilterAccount *pfAccount = new PasswordFilterAccount();
+	pfAccount->AccountName = AccountName;
+	pfAccount->Password = Password;
+
+	//start an asynchronous thread to be able to kill the thread if it exceeds the timout
+	HANDLE pfHandle = (HANDLE)_beginthreadex(0, 0, CreateSocket, (LPVOID *)pfAccount, 0, 0);
+
+	DWORD dWaitFor = WaitForSingleObject(pfHandle, 30000); //do not exceed the timeout
+	if (dWaitFor == WAIT_TIMEOUT) {
+		//timeout exceeded
+	}
+	else if (dWaitFor == WAIT_OBJECT_0) {
+		//here is where we want to be
+	}
+	else {
+		//WAIT_ABANDONED
+		//WAIT_FAILED
+	}
+
+	if (pfHandle != INVALID_HANDLE_VALUE && pfHandle != 0) {
+		if (CloseHandle(pfHandle)) {
+			pfHandle = INVALID_HANDLE_VALUE;
+		}
+	}
+
+	return bPasswordOk;
+}


### PR DESCRIPTION
During tests, i noticed that OPF did not support unicode. What happend was, upon sending this little snowflake: passw❄rd, that wcstombs returned an empty string, and therefore it could not be terminated with the \n. When it did not terminate, OpenPasswordFilter send **no** data indefinitely to the OPFService, and that causes a DC to hang, even logging in becomes problematic due to LSASS not being available.

With this knowledge i built another failsafe: multithreading. With that OpenPasswordFilter will wait 30 seconds before killing the askserver and, being true to the fail open concept, return a true.

I hope my updates are worthy, it is my first c++ commit :).
