### PR TITLE
OPFService now cleanly closes the socket upon exiting

### DIFF
--- a/OPFService/Program.cs
+++ b/OPFService/Program.cs
@@ -24,6 +24,7 @@ using System.IO;
 namespace OPFService {
     class OPFService : ServiceBase {
         Thread worker;
+        NetworkService svc;
 
         public OPFService() {
         }
@@ -36,13 +37,21 @@ namespace OPFService {
             base.OnStart(args);
             OPFDictionary d = new OPFDictionary(AppDomain.CurrentDomain.BaseDirectory + "\\opfmatch.txt", AppDomain.CurrentDomain.BaseDirectory + "opfcont.txt");
             // OPFDictionary d = new OPFDictionary("c:\\windows\\system32\\opfmatch.txt", "c:\\windows\\system32\\opfcont.txt");
-            NetworkService svc = new NetworkService(d);
+            svc = new NetworkService(d);
             worker = new Thread(() => svc.main());
             worker.Start();
         }
 
         protected override void OnShutdown() {
             base.OnShutdown();
+            svc.Close();
+            worker.Abort();
+        }
+
+        protected override void OnStop()
+        {
+            base.OnStop();
+            svc.Close();
             worker.Abort();
         }
 


### PR DESCRIPTION
When the OPF service is restarted, the service will come back but the socket will not be created. The old socket itself waits 30 seconds until it is automatically closed, by that time the OPFService is already running again, but the NetworkService will not be instantiated. Therefore svc is now available for the OPFService class and therefore OnShutdown and OnStop will call the Close() function of the NetworkService. OnStop had to be implemented, OnShutdown never seams to be called (maybe only on a real system shutdown?). Also, the NetworkService now waits 4 times 30 seconds when the socket is in use on startup, you'll never know if that is needed :).